### PR TITLE
Use plugdev group instead of uaccess for Fobos SDR udev rule

### DIFF
--- a/fobos-sdr.rules
+++ b/fobos-sdr.rules
@@ -18,5 +18,5 @@
 #
 
 # original Fobos SDR
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="132e", MODE="0660", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="132e", MODE="0660", GROUP="plugdev"
 


### PR DESCRIPTION
Changed the udev rule for the Fobos SDR to assign the device to the 'plugdev' group
instead of using TAG+="uaccess". Using plugdev avoids relying on session-based permission granting and simplifies
access control via traditional UNIX group membership. SDR apps now detect the device reliably when the user is in the plugdev group. This approach also mirrors the udev rules used by other SDR hardware such as RTL-SDR
and bladeRF, which rely on plugdev for straightforward group-based access control.