### PR TITLE
Update continuous integration workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,31 +16,31 @@ jobs:
       matrix:
         toolchain:
         - name: Linux Clang
-          os: ubuntu-24.04
+          os: ubuntu-latest
           cmake_args: -DCMAKE_C_COMPILER=clang
 
         - name: Linux GCC
-          os: ubuntu-24.04
+          os: ubuntu-latest
 
         - name: macOS ARM
-          os: macos-14
+          os: macos-26
 
         - name: macOS Intel
-          os: macos-13
+          os: macos-26-intel
 
         - name: MinGW
-          os: windows-2022
+          os: windows-latest
           cmake_args: -G "MinGW Makefiles"
 
         - name: MSVC 32-bit
-          os: windows-2022
+          os: windows-latest
           cmake_args: -A Win32
 
         - name: MSVC 64-bit
-          os: windows-2022
+          os: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install Linux Dependencies
       if: runner.os == 'Linux'
@@ -50,7 +50,7 @@ jobs:
     - name: Install Windows Dependencies
       if: runner.os == 'Windows'
       run: |
-        LIBUSB_VERSION=1.0.28
+        LIBUSB_VERSION=1.0.30
         LIBUSB_PACKAGE=libusb-$LIBUSB_VERSION.7z
         aria2c -q https://github.com/libusb/libusb/releases/download/v$LIBUSB_VERSION/$LIBUSB_PACKAGE
         7z x $LIBUSB_PACKAGE -olibusb
@@ -63,14 +63,10 @@ jobs:
       run: |
         cmake -B build ${{ matrix.toolchain.cmake_args }} .
 
-    - name: Get Number of CPU Cores
-      uses: SimenB/github-actions-cpu-cores@v2
-      id: cpu-cores
-
     - name: Build
       run: |
         export MAKEFLAGS=--keep-going
-        cmake --build build --config Release --parallel ${{ steps.cpu-cores.outputs.count }}
+        cmake --build build --config Release
 
     - name: Install Linux/macOS
       if: runner.os != 'Windows'


### PR DESCRIPTION
This fixes stuck macOS build, and remove warnings as well.

* Use latest GitHub Actions runners when possible. When macOS Intel support will end, the corresponding runner can be switched to macos-latest as well
* Update libusb to 1.0.30
* Remove parallel build as it was relying on deprecated version of nodejs