### PR TITLE
Add raw integer mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,5 @@ CMakeFiles
 debian/*.debhelper.log
 obj-x86_64-linux-gnu
 obj-aarch64-linux-gnu
+.*.~undo-tree~
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ target_include_directories(libfobos PUBLIC
 set_target_properties(libfobos PROPERTIES DEFINE_SYMBOL "FOBOS_EXPORTS")
 set_target_properties(libfobos PROPERTIES OUTPUT_NAME fobos)
 set_target_properties(libfobos PROPERTIES
-    VERSION 2.4.1
+    VERSION 2.5.0
     SOVERSION 0
 )
 ########################################################################

--- a/fobos/fobos.c
+++ b/fobos/fobos.c
@@ -116,6 +116,8 @@ struct fobos_dev_t
     uint32_t rx_bw_adj;
     uint32_t rx_direct_sampling;
     fobos_rx_cb_t rx_cb;
+    fobos_rx_raw_cb_t rx_raw_cb;
+    int rx_raw_mode;
     void *rx_cb_ctx;
     enum fobos_async_status rx_async_status;
     int rx_async_cancel;
@@ -1908,11 +1910,21 @@ static void LIBUSB_CALL _libusb_callback(struct libusb_transfer *transfer)
         {
             //printf_internal(".");
             dev->rx_buff_counter++;
-            fobos_rx_convert_samples(dev, transfer->buffer, transfer->actual_length, dev->rx_buff);
             uint32_t complex_samples_count = transfer->actual_length / 4;
-            if (dev->rx_cb)
+            if (dev->rx_raw_mode)
             {
-                dev->rx_cb(dev->rx_buff, complex_samples_count, dev->rx_cb_ctx);
+                if (dev->rx_raw_cb)
+                {
+                    dev->rx_raw_cb((const uint16_t *)transfer->buffer, complex_samples_count, dev->rx_cb_ctx);
+                }
+            }
+            else
+            {
+                fobos_rx_convert_samples(dev, transfer->buffer, transfer->actual_length, dev->rx_buff);
+                if (dev->rx_cb)
+                {
+                    dev->rx_cb(dev->rx_buff, complex_samples_count, dev->rx_cb_ctx);
+                }
             }
         }
         else
@@ -1943,7 +1955,7 @@ static void LIBUSB_CALL _libusb_callback(struct libusb_transfer *transfer)
     }
 }
 //==============================================================================
-int fobos_rx_read_async(struct fobos_dev_t * dev, fobos_rx_cb_t cb, void *ctx, uint32_t buf_count, uint32_t buf_length)
+static int fobos_rx_read_async_common(struct fobos_dev_t * dev, fobos_rx_cb_t cb, fobos_rx_raw_cb_t raw_cb, int raw_mode, void *ctx, uint32_t buf_count, uint32_t buf_length)
 {
     int result = fobos_check(dev);
 #ifdef FOBOS_PRINT_DEBUG
@@ -1965,6 +1977,8 @@ int fobos_rx_read_async(struct fobos_dev_t * dev, fobos_rx_cb_t cb, void *ctx, u
     dev->rx_async_cancel = 0;
     dev->rx_buff_counter = 0;
     dev->rx_cb = cb;
+    dev->rx_raw_cb = raw_cb;
+    dev->rx_raw_mode = raw_mode;
     dev->rx_cb_ctx = ctx;
     dev->rx_avg_re = 0.0f;
     dev->rx_avg_im = 0.0f;
@@ -1995,7 +2009,16 @@ int fobos_rx_read_async(struct fobos_dev_t * dev, fobos_rx_cb_t cb, void *ctx, u
         return result;
     }
 
-    dev->rx_buff = (float*)malloc(buf_length * 2 * sizeof(float));
+    if (!raw_mode)
+    {
+        dev->rx_buff = (float*)malloc(buf_length * 2 * sizeof(float));
+        if (!dev->rx_buff)
+        {
+            fobos_free_buffers(dev);
+            dev->rx_async_status = FOBOS_IDDLE;
+            return FOBOS_ERR_NO_MEM;
+        }
+    }
 
     fobos_fx3_command(dev, 0xE1, 1, 0);        // start fx
 
@@ -2085,6 +2108,16 @@ int fobos_rx_read_async(struct fobos_dev_t * dev, fobos_rx_cb_t cb, void *ctx, u
     return result;
 }
 //==============================================================================
+int fobos_rx_read_async(struct fobos_dev_t * dev, fobos_rx_cb_t cb, void *ctx, uint32_t buf_count, uint32_t buf_length)
+{
+    return fobos_rx_read_async_common(dev, cb, NULL, 0, ctx, buf_count, buf_length);
+}
+//==============================================================================
+int fobos_rx_read_async_raw(struct fobos_dev_t * dev, fobos_rx_raw_cb_t cb, void *ctx, uint32_t buf_count, uint32_t buf_length)
+{
+    return fobos_rx_read_async_common(dev, NULL, cb, 1, ctx, buf_count, buf_length);
+}
+//==============================================================================
 int fobos_rx_cancel_async(struct fobos_dev_t * dev)
 {
     int result = fobos_check(dev);
@@ -2103,10 +2136,8 @@ int fobos_rx_cancel_async(struct fobos_dev_t * dev)
     return 0;
 }
 //==============================================================================
-int fobos_rx_start_sync(struct fobos_dev_t * dev, uint32_t buf_length)
+static int fobos_rx_start_sync_common(struct fobos_dev_t * dev, uint32_t buf_length, int raw_mode)
 {
-    int i = 0;
-    int actual = 0;
     int result = fobos_check(dev);
 #ifdef FOBOS_PRINT_DEBUG
     printf_internal("%s()\n", __FUNCTION__);
@@ -2128,19 +2159,37 @@ int fobos_rx_start_sync(struct fobos_dev_t * dev, uint32_t buf_length)
         buf_length = FOBOS_DEF_BUF_LENGTH;
     }
     buf_length = 128 * (buf_length / 128);
-    dev->rx_buff = (float*)malloc(buf_length * 2 * sizeof(float));
     dev->transfer_buf_size = buf_length * 4;
-    dev->rx_sync_buf = (unsigned char *)malloc(dev->transfer_buf_size);
-    if (dev->rx_sync_buf == 0)
+    if (!raw_mode)
     {
-        dev->transfer_buf_size = 0;
-        return FOBOS_ERR_NO_MEM;
+        dev->rx_buff = (float*)malloc(buf_length * 2 * sizeof(float));
+        dev->rx_sync_buf = (unsigned char *)malloc(dev->transfer_buf_size);
+        if (!dev->rx_buff || !dev->rx_sync_buf)
+        {
+            free(dev->rx_buff);
+            free(dev->rx_sync_buf);
+            dev->rx_buff = NULL;
+            dev->rx_sync_buf = NULL;
+            dev->transfer_buf_size = 0;
+            return FOBOS_ERR_NO_MEM;
+        }
     }
     fobos_fx3_command(dev, 0xE1, 1, 0);        // start fx
     bitclear(dev->dev_gpo, FOBOS_DEV_ADC_SDI);
     fobos_rx_set_dev_gpo(dev, dev->dev_gpo);
+    dev->rx_raw_mode = raw_mode;
     dev->rx_sync_started = 1;
     return FOBOS_ERR_OK;
+}
+//==============================================================================
+int fobos_rx_start_sync(struct fobos_dev_t * dev, uint32_t buf_length)
+{
+    return fobos_rx_start_sync_common(dev, buf_length, 0);
+}
+//==============================================================================
+int fobos_rx_start_sync_raw(struct fobos_dev_t * dev, uint32_t buf_length)
+{
+    return fobos_rx_start_sync_common(dev, buf_length, 1);
 }
 //==============================================================================
 int fobos_rx_read_sync(struct fobos_dev_t * dev, float * buf, uint32_t * actual_buf_length)
@@ -2158,6 +2207,10 @@ int fobos_rx_read_sync(struct fobos_dev_t * dev, float * buf, uint32_t * actual_
     {
         return FOBOS_ERR_SYNC_NOT_STARTED;
     }
+    if (dev->rx_raw_mode)
+    {
+        return FOBOS_ERR_UNSUPPORTED;
+    }
     result = libusb_bulk_transfer(
         dev->libusb_devh,
         LIBUSB_BULK_IN_ENDPOINT,
@@ -2172,6 +2225,46 @@ int fobos_rx_read_sync(struct fobos_dev_t * dev, float * buf, uint32_t * actual_
         {
             *actual_buf_length = actual / 4;
         }
+    }
+    return result;
+}
+//==============================================================================
+int fobos_rx_read_sync_raw(struct fobos_dev_t * dev, uint16_t * buf, uint32_t buf_length, uint32_t * actual_buf_length)
+{
+    int actual = 0;
+    int result = fobos_check(dev);
+    if (result != FOBOS_ERR_OK)
+    {
+        return result;
+    }
+    if (dev->rx_sync_started != 1)
+    {
+        return FOBOS_ERR_SYNC_NOT_STARTED;
+    }
+    if (!dev->rx_raw_mode)
+    {
+        return FOBOS_ERR_UNSUPPORTED;
+    }
+    if (!buf || buf_length == 0)
+    {
+        return FOBOS_ERR_NO_MEM;
+    }
+
+    uint64_t requested_bytes = (uint64_t)buf_length * 4;
+    if (requested_bytes > dev->transfer_buf_size)
+    {
+        requested_bytes = dev->transfer_buf_size;
+    }
+    result = libusb_bulk_transfer(
+        dev->libusb_devh,
+        LIBUSB_BULK_IN_ENDPOINT,
+        (unsigned char *)buf,
+        (int)requested_bytes,
+        &actual,
+        LIBUSB_BULK_TIMEOUT);
+    if (result == FOBOS_ERR_OK && actual_buf_length)
+    {
+        *actual_buf_length = (uint32_t)actual / 4;
     }
     return result;
 }

--- a/fobos/fobos.c
+++ b/fobos/fobos.c
@@ -17,6 +17,7 @@
 //  2025.01.19 - v.2.3.2 fobos_rx_reset()
 //  2025.08.23 - v.2.4.0 DC filter improved, VGA gain fixed
 //  2025.10.23 - v.2.4.1 new software DC filter
+//  2026.09.01 - v.2.5.0 add raw mode
 //==============================================================================
 #ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS

--- a/fobos/fobos.c
+++ b/fobos/fobos.c
@@ -405,10 +405,10 @@ int fobos_max2830_set_frequency(struct fobos_dev_t * dev, double value, double *
     }
     double div = value / fcomp;
     uint32_t div_int = (uint32_t)(div) & 0x000000FF;
-    uint32_t div_frac = (uint32_t)((div - div_int) * 1048575.0 + 0.5);
+    uint32_t div_frac = (uint32_t)((div - div_int) * 1048576.0);
     if (actual)
     {
-        div = (double)(div_int) + (double)(div_frac) / 1048575.0;
+        div = (double)(div_int) + (double)(div_frac) / 1048576.0;
         *actual = div * fcomp;
     }
     fobos_max2830_write_reg(dev, 3, ((div_frac << 8) | div_int) & 0x3FFF);
@@ -545,7 +545,7 @@ int fobos_rffc507x_init(struct fobos_dev_t * dev)
     return FOBOS_ERR_NO_DEV;
 }
 //==============================================================================
-int fobos_rffc507x_set_lo_frequency_hz(struct fobos_dev_t * dev, uint64_t lo_freq_hz, uint64_t * tune_freq_hz)
+int fobos_rffc507x_set_lo_frequency_hz(struct fobos_dev_t * dev, uint64_t lo_freq_hz, double * tune_freq_hz)
 {
     uint64_t lodiv;
     uint64_t fvco;
@@ -586,7 +586,7 @@ int fobos_rffc507x_set_lo_frequency_hz(struct fobos_dev_t * dev, uint64_t lo_fre
 
     p1nmsb = (tmp_n >> 13ULL) & 0xffff;
     p1nlsb = (tmp_n >> 5ULL) & 0xff;
-    uint64_t freq_hz = (fref * (tmp_n >> 5ULL) * fbkdiv) / (lodiv * (1 << 24ULL));
+    double freq_hz = (fref * ((tmp_n >> 5ULL) + 0.5) * fbkdiv) / (lodiv * (1 << 24ULL));
     if (tune_freq_hz)
     {
         *tune_freq_hz = freq_hz;
@@ -609,8 +609,7 @@ int fobos_rffc507x_set_lo_frequency_hz(struct fobos_dev_t * dev, uint64_t lo_fre
     fobos_rffc507x_register_modify(&dev->rffc507x_registers_local[0x15], 14, 14, 1); // enbl = 1
     fobos_rffc507x_commit(dev, 0);
 #ifdef FOBOS_PRINT_DEBUG
-    double ff = (double)freq_hz;
-    printf_internal("rffc507x lo_freq_mhz = %llu %f\n", (unsigned long long)lo_freq_hz, ff);
+    printf_internal("rffc507x lo_freq_mhz = %llu %f\n", (unsigned long long)lo_freq_hz, freq_hz);
 #endif // FOBOS_PRINT_DEBUG
     return 0;
 }
@@ -1242,7 +1241,7 @@ int fobos_rx_set_frequency(struct fobos_dev_t * dev, double value, double * actu
         double max2830_freq = 0.0;
         double max2830_freq_actual = 0.0;
         uint64_t RFFC5071_freq;
-        uint64_t RFFC5071_freq_hz_actual;
+        double RFFC5071_freq_hz_actual;
         double rx_frequency = 0.0;
         switch (fobos_rx_bands[idx].rffc507x_inject)
         {

--- a/fobos/fobos.h
+++ b/fobos/fobos.h
@@ -46,6 +46,17 @@ extern "C"
 //==============================================================================
 struct fobos_dev_t;
 typedef void(*fobos_rx_cb_t)(float *buf, uint32_t buf_length, void *ctx);
+/*
+ * Raw receive buffers contain interleaved 16-bit ADC words exactly as supplied
+ * by the device, in Q,I word order. The 14-bit unsigned offset-binary sample
+ * is in bits 0..13.
+ * No masking, I/Q swapping, DC removal, gain correction, or scaling is done.
+ *
+ * The asynchronous buffer belongs to libfobos and is valid only until the
+ * callback returns. The callback runs on the libusb event-handling thread.
+ * buf_length is the number of complex samples (two uint16_t words each).
+ */
+typedef void(*fobos_rx_raw_cb_t)(const uint16_t *buf, uint32_t buf_length, void *ctx);
 //==============================================================================
 // obtain the software info
 API_EXPORT int CALL_CONV fobos_rx_get_api_info(char * lib_version, char * drv_version);
@@ -75,6 +86,8 @@ API_EXPORT int CALL_CONV fobos_rx_get_samplerates(struct fobos_dev_t * dev, doub
 API_EXPORT int CALL_CONV fobos_rx_set_samplerate(struct fobos_dev_t * dev, double value, double * actual);
 // statr the iq rx streaming
 API_EXPORT int CALL_CONV fobos_rx_read_async(struct fobos_dev_t * dev, fobos_rx_cb_t cb, void *ctx, uint32_t buf_count, uint32_t buf_length);
+// start raw iq streaming; callback buffer is valid only for the callback duration
+API_EXPORT int CALL_CONV fobos_rx_read_async_raw(struct fobos_dev_t * dev, fobos_rx_raw_cb_t cb, void *ctx, uint32_t buf_count, uint32_t buf_length);
 // stop the iq rx streaming
 API_EXPORT int CALL_CONV fobos_rx_cancel_async(struct fobos_dev_t * dev);
 // set user general purpose output bits (0x00 .. 0xFF)
@@ -87,8 +100,15 @@ API_EXPORT int CALL_CONV fobos_max2830_set_frequency(struct fobos_dev_t * dev, d
 API_EXPORT int CALL_CONV fobos_rffc507x_set_lo_frequency_hz(struct fobos_dev_t * dev, uint64_t lo_freq, uint64_t * tune_freq_hz);
 // start synchronous rx mode
 API_EXPORT int CALL_CONV fobos_rx_start_sync(struct fobos_dev_t * dev, uint32_t buf_length);
+// start synchronous raw rx mode without allocating a floating-point buffer
+API_EXPORT int CALL_CONV fobos_rx_start_sync_raw(struct fobos_dev_t * dev, uint32_t buf_length);
 // read samples in synchronous rx mode
 API_EXPORT int CALL_CONV fobos_rx_read_sync(struct fobos_dev_t * dev, float * buf, uint32_t * actual_buf_length);
+/*
+ * Read raw samples directly into buf. buf_length is its capacity in complex
+ * samples; actual_buf_length receives the number of complex samples read.
+ */
+API_EXPORT int CALL_CONV fobos_rx_read_sync_raw(struct fobos_dev_t * dev, uint16_t * buf, uint32_t buf_length, uint32_t * actual_buf_length);
 // stop synchronous rx mode
 API_EXPORT int CALL_CONV fobos_rx_stop_sync(struct fobos_dev_t * dev);
 // read firmware from the device

--- a/fobos/fobos.h
+++ b/fobos/fobos.h
@@ -97,7 +97,7 @@ API_EXPORT int CALL_CONV fobos_rx_set_clk_source(struct fobos_dev_t * dev, int v
 // explicitly set the max2830 frequency, Hz (23500000000 .. 2550000000)
 API_EXPORT int CALL_CONV fobos_max2830_set_frequency(struct fobos_dev_t * dev, double value, double * actual);
 // explicitly set rffc507x frequency, Hz (25000000 .. 5400000000)
-API_EXPORT int CALL_CONV fobos_rffc507x_set_lo_frequency_hz(struct fobos_dev_t * dev, uint64_t lo_freq, uint64_t * tune_freq_hz);
+API_EXPORT int CALL_CONV fobos_rffc507x_set_lo_frequency_hz(struct fobos_dev_t * dev, uint64_t lo_freq, double * tune_freq_hz);
 // start synchronous rx mode
 API_EXPORT int CALL_CONV fobos_rx_start_sync(struct fobos_dev_t * dev, uint32_t buf_length);
 // start synchronous raw rx mode without allocating a floating-point buffer


### PR DESCRIPTION
This adds raw sample support, bypassing the fobos_rx_convert_samples() function. Raw Q and I samples (lower 14 bits of 16-bit integers) are transferred to the user buffer without modification, saving an extra trip through memory that is expensive at high sample rates.

This raw mode has been tested with the fobos module in ka9q-radio. No IQ gain or phase correction is performed by the library in raw mode; this is the responsibility of the application. The corrections currently in ka9q-radio are flat over the frequency range; frequency-dependent corrections may be added later.

Note that the original fobos_rx_convert_samples() function only corrects for IQ gain imbalance, not phase errors. The ka9q-radio module now corrects for both, but the corrections are currently not frequency dependent; this may be added later if they prove beneficial.

I've bumped the libfobos version to 2.5.0. The SONAME remains at 0 because there are no backward-incompatible changes; only new functions have been added.
